### PR TITLE
Update dump.rb - Fixes encoding issue

### DIFF
--- a/lib/hasten/dump.rb
+++ b/lib/hasten/dump.rb
@@ -32,7 +32,7 @@ module Hasten
         return unless line = io_in.gets
 
         self.command = Command.new
-        self.command << line
+        self.command << line.encode("UTF-16be", :invalid=>:replace, :replace=>"?").encode('UTF-8')
         return command if command.complete?
 
         while line = io_in.gets


### PR DESCRIPTION
I've been using hasten for a while but for loads of files fail to import it because of invalid UTF8 chars.
It's one of the issue's posted on your repo.
All this does is replace broken characters with ? but at least db imports.
Hopefully someone will find this useful :)
